### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -8,8 +8,8 @@
 ###########################################
 
 PulseCom	KEYWORD1
-pulseCom_Timeout     KEYWORD1
-pulseCom_DataLength     KEYWORD1
+pulseCom_Timeout	KEYWORD1
+pulseCom_DataLength	KEYWORD1
 
 ###########################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords